### PR TITLE
Bilingual fields added on organization and groups search API

### DIFF
--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -1,10 +1,13 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import ckan.logic as logic
+import ckan.model as model
+
 from ckanext.fcscopendata.logic import action
 from ckan.lib.plugins import DefaultTranslation
 
 from flask import Blueprint, render_template
-
+from ckan.common import c
 
 def hello_plugin():
     return u'Hello from the fcscopendata Theme extension'
@@ -15,10 +18,34 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.ITranslation)
+    plugins.implements(plugins.IPackageController, inherit=True)
+
+    # IPackageController
+    def after_search(self, search_results, search_params):
+
+        # Update group and organization dict with translated fields.
+        for idx, results in enumerate(search_results['results']):
+            context = {'model': model, 'session': model.Session,
+                       'user': c.user, 'auth_user_obj': c.userobj}
+            if results.get('groups', []):
+                for gidx, group in enumerate(results.get('groups', [])):
+                    group_dict = logic.get_action('group_show')(context, {'id': group.get('id')})
+                    search_results['results'][idx]['groups'][gidx].update(
+                        {'title_translated' : group_dict.get('title_translated', {'ar': '', 'en': ''})})
+                    search_results['results'][idx]['groups'][gidx].update(
+                        {'description_translated' : group_dict.get('description_translated', {'ar': '', 'en': ''})})
+
+            if results.get('organization', {}):
+                org_dict = logic.get_action('organization_show')(context, {'id': results.get('organization', {})['id'] })
+                search_results['results'][idx]['organization'].update(
+                    {'title_translated' : org_dict.get('title_translated', {'ar': '', 'en': ''})})
+                search_results['results'][idx]['organization'].update(
+                    {'notes_translated' : org_dict.get('notes_translated', {'ar': '', 'en': ''})})
+
+        return search_results
 
 
     # IConfigurer
-
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
@@ -26,7 +53,6 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
                              'fcscopendata')
 
     # IBlueprint
-
     def get_blueprint(self):
         u'''Return a Flask Blueprint object to be registered by the app.'''
         # Create Blueprint for plugin


### PR DESCRIPTION
Fix for: #16
Bilingual fields added into package search result dict using  IPackageController `after_search` function.
After fix: 
<img width="799" alt="Screen Shot 2022-02-24 at 1 01 40 PM" src="https://user-images.githubusercontent.com/87696933/155476524-19e5b0ac-1b33-4577-9b37-804025fa0e57.png">
