### PR TITLE
categories tags dataset  association implemented

### DIFF
--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -47,6 +47,11 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
                 search_results['results'][idx]['organization'].update(
                     {'notes_translated' : org_dict.get('notes_translated', {'ar': '', 'en': ''})})
 
+            if results.get('tags', []):
+                for inindex, tag in enumerate(search_results['results'][idx]['tags']):
+                    search_results['results'][idx]['tags'][inindex] =  \
+                    logic.get_action('tag_show')(context, {'id': tag['id'] })
+                    
         return search_results
 
 

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -5,6 +5,7 @@ import ckan.model as model
 
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
+from ckanext.fcscopendata.views import vocab_tag_autocomplete
 
 from ckan.lib.plugins import DefaultTranslation
 
@@ -63,7 +64,8 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         blueprint = Blueprint(self.name, self.__module__)
         blueprint.template_folder = u'templates'
         # Add plugin url rules to Blueprint object
-        blueprint.add_url_rule('/hello_plugin', '/hello_plugin', hello_plugin)
+        blueprint.add_url_rule(u'/api/2/util/vocab/tag/autocomplete', methods=[u'GET'], 
+                                view_func=vocab_tag_autocomplete)
         return blueprint
 
     def get_actions(self):

--- a/ckanext/fcscopendata/views.py
+++ b/ckanext/fcscopendata/views.py
@@ -1,9 +1,8 @@
 import ckan.model as model
-from ckan.common import json, _, g, request
+from ckan.common import _, g, request
 from ckan.logic import get_action
 from ckan.views.api import _finish_ok
 
-API_REST_DEFAULT_VERSION = 1
 
 def vocab_tag_autocomplete():
     q = request.args.get(u'incomplete', u'')

--- a/ckanext/fcscopendata/views.py
+++ b/ckanext/fcscopendata/views.py
@@ -1,0 +1,32 @@
+import ckan.model as model
+from ckan.common import json, _, g, request
+from ckan.logic import get_action
+from ckan.views.api import _finish_ok
+
+API_REST_DEFAULT_VERSION = 1
+
+def vocab_tag_autocomplete():
+    q = request.args.get(u'incomplete', u'')
+    context = {u'model': model, u'session': model.Session,
+                   u'user': g.user, u'auth_user_obj': g.userobj}
+
+    limit = request.args.get(u'limit', 10)
+    vocab_list = get_action(u'vocabulary_list')(context, {})
+
+    tag_list = []
+    if q:
+        data_dict = {u'q': q, u'limit': limit}
+
+        for vocab in vocab_list:
+            tags = get_action(u'tag_autocomplete')(context, 
+                {**data_dict,'vocabulary_id': vocab['id'] })
+            for tag_item in tags:
+                tag_list.append(tag_item) 
+            
+    resultSet = {
+        u'ResultSet': {
+            u'Result': [{u'Name': tag} for tag in tag_list]
+        }
+    }
+
+    return _finish_ok(resultSet)


### PR DESCRIPTION
Fix for  #28 
Changes: - 
-  Removed Binlingual Keywords filed and replace with previous default tags field. 
-  Implemented Tags autocomplete with categories tags list. 
-  Implemented selected tags associate categories  with datasets
-  Restricted free tags creation.

NOTE: This PR is dependent with https://github.com/FCSCOpendata/ckanext-scheming/pull/6