### PR TITLE
Tags not searchable or tag facet not working  bug fixed 

### DIFF
--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -36,12 +36,13 @@ def package_create(up_func, context, data_dict):
     data_dict['notes'] =  data_dict.get('notes_translated-en', '')
 
     tags  = model.Session.query(model.tag.Tag).filter(model.tag.Tag.name.in_(
-    tag['name'] for tag in data_dict['tags'])).all()
+            tag['name'] for tag in data_dict['tags'])).all()
 
     tags_dict = model_dictize.tag_list_dictize(tags, context)
 
     for idx, tag in enumerate(data_dict['tags']):
-        data_dict['tags'][idx]['vocabulary_id'] = [t['vocabulary_id'] for t in tags_dict if t['name'] == tag['name']][0]
+        data_dict['tags'][idx]['vocabulary_id'] = \
+            [t.get('vocabulary_id', None) for t in tags_dict if t['name'] == tag['name']][0]
 
     # Do not create free tags. 
     data_dict['tag_string'] = ''
@@ -66,7 +67,8 @@ def package_update(up_func, context, data_dict):
     tags_dict = model_dictize.tag_list_dictize(tags, context)
 
     for idx, tag in enumerate(data_dict['tags']):
-        data_dict['tags'][idx]['vocabulary_id'] = [t['vocabulary_id'] for t in tags_dict if t['name'] == tag['name']][0]
+        data_dict['tags'][idx]['vocabulary_id'] = \
+            [t.get('vocabulary_id', None) for t in tags_dict if t['name'] == tag['name']][0]
 
     # Do not create free tags. 
     data_dict['tag_string'] = ''

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -55,6 +55,8 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return search_results
 
     def before_index(self, pkg_dict):
+        # Index vocab tags as tag field also so that
+        # it is searchable via default tag query.
         data_dict = json.loads(pkg_dict.get('data_dict', {}))
         if data_dict.get('tags', []):
             tag_list = []

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -2,7 +2,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
 import ckan.model as model
-
+import json
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
 from ckanext.fcscopendata.views import vocab_tag_autocomplete
@@ -54,6 +54,15 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
                     
         return search_results
 
+    def before_index(self, pkg_dict):
+        data_dict = json.loads(pkg_dict.get('data_dict', {}))
+        if data_dict.get('tags', []):
+            tag_list = []
+            tags = data_dict.get('tags', [])
+            for tag in tags:
+                tag_list.append(tag['name'])
+            pkg_dict['tags'] = tag_list
+        return pkg_dict
 
     # IConfigurer
     def update_config(self, config_):


### PR DESCRIPTION
Fix of #https://github.com/FCSCOpendata/ckanext-fcscopendata/issues/28#issuecomment-1060666643

## Changes in this PR
- Index vocab tags as default tags so it is searchable with tag query. 
- Improve in tags dataset association. (don't break if tag dict don't have vocabulary  dict key)