### PR TITLE
Groups icon upload feature implemented.

### DIFF
--- a/ckanext/fcscopendata/assets/home.css
+++ b/ckanext/fcscopendata/assets/home.css
@@ -793,6 +793,18 @@ button.active {
   border-radius: 30px;
   border-color: #eee;
 }
+
+.context-info .icon {
+  margin-top: -35px;
+}
+
+.context-info .icon img {
+  border-radius: 50px;
+  border: 2px solid #f7f7f7;
+  background: #fff;
+  padding: 2px;
+}
+
 /**** Responsive CSS *****/
 @media only screen and (max-width: 768px) {
   .navbar-toggle {

--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -113,7 +113,9 @@ def organization_show(up_func,context,data_dict):
         result['icon_display_url'] = h.url_for_static(
                 'uploads/group/%s' % result.get('icon_url'),
                 qualified=True
-            )                                                                                                                                                                                                                                                                                                                 
+            )
+    else:
+         result['icon_display_url'] = result.get('icon_url') or ''                                                                                                                                                                                                                                                                                                             
     return result
 
 @p.toolkit.chained_action                                                                                                                                                    
@@ -154,7 +156,9 @@ def group_show(up_func,context,data_dict):
         result['icon_display_url'] = h.url_for_static(
                 'uploads/group/%s' % result.get('icon_url'),
                 qualified=True
-            )                                                                                                                                                                                                                                                                                                                 
+            )
+    else:
+         result['icon_display_url'] = result.get('icon_url') or ''                                                                                                                                                                                                                                                                                                                
     return result
 
 @p.toolkit.chained_action                                                                                                                                                    

--- a/ckanext/fcscopendata/templates/group/snippets/info.html
+++ b/ckanext/fcscopendata/templates/group/snippets/info.html
@@ -8,6 +8,11 @@
         <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" width="190" height="118" alt="{{ group.name }}" />
       </a>
     </div>
+    <div class="icon">
+      {% if group.icon_display_url %}
+          <img src="{{ group.icon_display_url }}" width="50" height="50" alt="{{ group.name }}" />
+      {% endif %}   
+    </div>
     {% endblock %}
     {% block heading %}
     <h1 class="heading">

--- a/ckanext/fcscopendata/templates/snippets/organization.html
+++ b/ckanext/fcscopendata/templates/snippets/organization.html
@@ -30,6 +30,11 @@ Example:
             <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" width="200" alt="{{ organization.name }}" />
           </a>
         </div>
+        <div class="icon">
+          {% if organization.icon_display_url %}
+          <img src="{{ organization.icon_display_url }}" width="50" height="50" alt="{{ organization.name }}" />
+        {% endif %}
+        </div>
       {% endblock %}
       {% block heading %}
       <h1 class="heading">{{ organization.title or organization.name }}


### PR DESCRIPTION
This PR is dependent on https://github.com/FCSCOpendata/ckanext-scheming/pull/9. 
- Icon upload function added in organization and group create/ update action. 
- Changes to return full icon url  on `organization_show` and `group_show` action. 

**Screenshot**
<img width="985" alt="Screen Shot 2022-04-15 at 5 58 00 PM" src="https://user-images.githubusercontent.com/87696933/163569401-9791d422-12dc-4531-9b79-f4c28921769e.png">

