### PR TITLE
Code refractor and only add bilingual fields if search action is called via API

### DIFF
--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -59,7 +59,7 @@ def extras_save(extra_dicts, model_obj, context):
 def package_search(up_func, context, data_dict):
     result = up_func(context, data_dict)
     # Only add bilingual fields if the action is called from API.
-    if context.get('request_from_ui', False):
+    if not context.get('request_from_ui', False):
         context = {'model': model, 'session': model.Session,
                     'user': c.user, 'auth_user_obj': c.userobj}
                     

--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -11,6 +11,8 @@ from ckan.plugins.toolkit import ValidationError
 from datetime import date, datetime
 import ckan.lib.helpers as h
 import ckan.lib.uploader as uploader
+import ckan.model as model
+from ckan.common import c
 
 
 ValidationError = logic.ValidationError
@@ -50,6 +52,32 @@ def extras_save(extra_dicts, model_obj, context):
             model_obj.extras[x['key']] = x['value']
     if not context.get('defer_commit'):
         model.repo.commit()
+
+
+@p.toolkit.chained_action
+@logic.side_effect_free
+def package_search(up_func, context, data_dict):
+    result = up_func(context, data_dict)
+    # Only add bilingual fields if the action is called from API.
+    if context.get('request_from_ui', False):
+        context = {'model': model, 'session': model.Session,
+                    'user': c.user, 'auth_user_obj': c.userobj}
+                    
+        for idx, pkg in enumerate(result['results']):
+            if pkg.get('groups', []):
+                for gidx, group in enumerate(pkg.get('groups', [])):
+                    group_dict = logic.get_action('group_show')(context, {'id': group.get('id')})
+                    result['results'][idx]['groups'][gidx] = group_dict
+
+            if pkg.get('organization', {}):
+                org_dict = logic.get_action('organization_show')(context, {'id': pkg.get('organization', {})['id'] })
+                result['results'][idx]['organization'] = org_dict
+
+            if pkg.get('tags', []):
+                for index, tag in enumerate(result['results'][idx]['tags']):
+                    result['results'][idx]['tags'][index] =  \
+                    logic.get_action('tag_show')(context, {'id': tag['id'] })
+    return result
 
 
 @p.toolkit.chained_action
@@ -527,7 +555,8 @@ def get_actions():
         'vocabulary_create': vocabulary_create,
         'vocabulary_update': vocabulary_update,
         'vocabulary_show': vocabulary_show,
-        'package_show': package_show
+        'package_show': package_show,
+        'package_search': package_search
     }
 
 

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -29,29 +29,23 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     # IPackageController
     def after_search(self, search_results, search_params):
-
         # Update group and organization dict with translated fields.
-        for idx, results in enumerate(search_results['results']):
-            context = {'model': model, 'session': model.Session,
-                       'user': c.user, 'auth_user_obj': c.userobj}
-            if results.get('groups', []):
-                for gidx, group in enumerate(results.get('groups', [])):
+        context = {'model': model, 'session': model.Session,
+                    'user': c.user, 'auth_user_obj': c.userobj}
+
+        for idx, pkg in enumerate(search_results['results']):
+            if pkg.get('groups', []):
+                for gidx, group in enumerate(pkg.get('groups', [])):
                     group_dict = logic.get_action('group_show')(context, {'id': group.get('id')})
-                    search_results['results'][idx]['groups'][gidx].update(
-                        {'title_translated' : group_dict.get('title_translated', {'ar': '', 'en': ''})})
-                    search_results['results'][idx]['groups'][gidx].update(
-                        {'description_translated' : group_dict.get('description_translated', {'ar': '', 'en': ''})})
+                    search_results['results'][idx]['groups'][gidx] = group_dict
 
-            if results.get('organization', {}):
-                org_dict = logic.get_action('organization_show')(context, {'id': results.get('organization', {})['id'] })
-                search_results['results'][idx]['organization'].update(
-                    {'title_translated' : org_dict.get('title_translated', {'ar': '', 'en': ''})})
-                search_results['results'][idx]['organization'].update(
-                    {'notes_translated' : org_dict.get('notes_translated', {'ar': '', 'en': ''})})
+            if pkg.get('organization', {}):
+                org_dict = logic.get_action('organization_show')(context, {'id': pkg.get('organization', {})['id'] })
+                search_results['results'][idx]['organization'] = org_dict
 
-            if results.get('tags', []):
-                for inindex, tag in enumerate(search_results['results'][idx]['tags']):
-                    search_results['results'][idx]['tags'][inindex] =  \
+            if pkg.get('tags', []):
+                for index, tag in enumerate(search_results['results'][idx]['tags']):
+                    search_results['results'][idx]['tags'][index] =  \
                     logic.get_action('tag_show')(context, {'id': tag['id'] })
                     
         return search_results

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -1,7 +1,5 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
-import ckan.logic as logic
-import ckan.model as model
 import json
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
@@ -11,7 +9,6 @@ from ckanext.fcscopendata.helpers import get_package_download_stats
 from ckan.lib.plugins import DefaultTranslation
 
 from flask import Blueprint, render_template
-from ckan.common import c
 
 def hello_plugin():
     return u'Hello from the fcscopendata Theme extension'
@@ -28,28 +25,6 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
 
     # IPackageController
-    def after_search(self, search_results, search_params):
-        # Update group and organization dict with translated fields.
-        context = {'model': model, 'session': model.Session,
-                    'user': c.user, 'auth_user_obj': c.userobj}
-
-        for idx, pkg in enumerate(search_results['results']):
-            if pkg.get('groups', []):
-                for gidx, group in enumerate(pkg.get('groups', [])):
-                    group_dict = logic.get_action('group_show')(context, {'id': group.get('id')})
-                    search_results['results'][idx]['groups'][gidx] = group_dict
-
-            if pkg.get('organization', {}):
-                org_dict = logic.get_action('organization_show')(context, {'id': pkg.get('organization', {})['id'] })
-                search_results['results'][idx]['organization'] = org_dict
-
-            if pkg.get('tags', []):
-                for index, tag in enumerate(search_results['results'][idx]['tags']):
-                    search_results['results'][idx]['tags'][index] =  \
-                    logic.get_action('tag_show')(context, {'id': tag['id'] })
-                    
-        return search_results
-
     def before_index(self, pkg_dict):
         # Index vocab tags as tag field also so that
         # it is searchable via default tag query.


### PR DESCRIPTION
Fix for https://github.com/FCSCOpendata/fcsc-deploy/issues/20

This PR includes the following changes.
-  Remove the `after_search` function and replaced it with toolchain action.
-  Check request source in context dict and add bilingual fields only if the search action is called via API.

**Note**:  Following patch needs to be added, otherwise it wouldn’t work properly. 

``` python
diff --git a/ckan/views/dataset.py b/ckan/views/dataset.py
index e057dcaab..05b639dc4 100644
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -312,6 +312,7 @@ def search(package_type):
             config.get(u'ckan.search.default_include_private', True)
         ),
     }
+    context['request_from_ui'] = True
     try:
         query = get_action(u'package_search')(context, data_dict)
 
diff --git a/ckan/views/user.py b/ckan/views/user.py
index b94324232..8ba22262b 100644
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -53,6 +53,7 @@ def _new_form_to_db_schema():
 
 
 def _extra_template_variables(context, data_dict):
+    context['request_from_ui'] = True
     is_sysadmin = authz.is_sysadmin(g.user)
     try:
         user_dict = logic.get_action(u'user_show')(context, data_dict)

```