### PR TITLE
enable proper listing of themes and subthemes

### DIFF
--- a/ckanext/fcscopendata/templates/package/group_list.html
+++ b/ckanext/fcscopendata/templates/package/group_list.html
@@ -17,7 +17,7 @@
 
   {% if pkg_dict.groups %}
     <form method="post">
-      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups %}
+      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups, pkg_dict=pkg_dict %}
     </form>
   {% else %}
     <p class="empty">{{ _('There are no groups associated with this dataset') }}</p>


### PR DESCRIPTION
This pr enables the correct display of themes and subthemes #59 

![Screenshot 2022-05-30 at 14 55 48](https://user-images.githubusercontent.com/20904032/171010994-124aadf9-1185-4bae-bcac-c97f0ea11982.png)

