### PR TITLE
Create/update draft dataset feature implemented

### DIFF
--- a/ckanext/fcscopendata/assets/home.css
+++ b/ckanext/fcscopendata/assets/home.css
@@ -695,6 +695,12 @@ button.active {
   background-color: #c9a926;
   border-color: #c9a926;
 }
+
+button.btn.btn-warning:hover{
+  background-color: #ec971f !important;
+  border-color: #d58512;
+}
+
 .wrapper {
   border: 1px solid #e0e0e0;
   border-radius: 0;

--- a/ckanext/fcscopendata/assets/home.css
+++ b/ckanext/fcscopendata/assets/home.css
@@ -592,7 +592,8 @@ button.active {
 .dataset-status-label span {
   margin-left: 2px;
   font-size: 12px;
-  text-transform: uppercase;
+  text-transform: capitalize;
+  font-weight: 600;
 }
 
 /* About */

--- a/ckanext/fcscopendata/assets/home.css
+++ b/ckanext/fcscopendata/assets/home.css
@@ -581,6 +581,20 @@ button.active {
 .stages li.active:before {
   color: #252525;
 }
+
+/* label */
+.dataset-status-label {
+  display: flex;
+  justify-content: flex-end;
+  flex-direction: row;
+}
+
+.dataset-status-label span {
+  margin-left: 2px;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
 /* About */
 .about .page-heading {
   color: #003164;

--- a/ckanext/fcscopendata/assets/javascript/form-submit.js
+++ b/ckanext/fcscopendata/assets/javascript/form-submit.js
@@ -1,0 +1,40 @@
+this.ckan.module('form-save', function (jQuery) {
+  return {
+    /* An object of module options */
+    options: {
+      type:''
+    },
+    /* Sets up the event listeners for the object. Called internally by
+     * module.createInstance().
+     *
+     * Returns nothing.
+     */
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/);
+      this.el.on('click', this._onClick);
+    },
+
+    /* Event handler that displays the confirm dialog */
+    _onClick: function (event) {
+    
+      if(this.options.type === 'draft'){
+        event.preventDefault();
+        var form = $('#dataset-edit')
+        $('#field-publishing_status').val('draft')
+        form.find('button[name=save]').click()
+      }
+      if(this.options.type === 'published'){
+        event.preventDefault();
+        var form = $('#dataset-edit')
+        $('#field-publishing_status').val('published')
+        form.find('button[name=save]').click()
+      }
+      if(this.options.type === 'resource-draft'){
+        event.preventDefault();
+        var form = $('#resource-edit')
+        $('#field-pkg_publishing_status').val('draft')
+        form.find('button[value=go-metadata]').click()
+      }
+    },
+  };
+});

--- a/ckanext/fcscopendata/assets/webassets.yml
+++ b/ckanext/fcscopendata/assets/webassets.yml
@@ -13,6 +13,15 @@
 #   contents:
 #     - css/fcscopendata.css
 
+fcsc_js:
+  filter: rjsmin
+  output: ckanext-fcscopendata/%(version)s-form-submit.js
+  contents:
+    - javascript/form-submit.js
+  extra:
+    preload:
+      - base/main
+
 home_css:
   filter: cssrewrite
   output: ckanext-fcscopendata/%(version)s-home.css

--- a/ckanext/fcscopendata/helpers.py
+++ b/ckanext/fcscopendata/helpers.py
@@ -7,3 +7,11 @@ def get_package_download_stats(package_id):
     context = {'model': model, 'session': model.Session}
     stats = logic.get_action('package_show')(context, {'id': package_id})
     return stats['total_downloads']
+
+def is_dataset_draft(package_id):
+    context = {'model': model, 'session': model.Session}
+    dataset = logic.get_action('package_show')(context, {'id': package_id})
+    if dataset.get('publishing_status', '') == 'draft':
+        return True
+    else:
+        return False

--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -546,16 +546,28 @@ def package_show(up_func,context,data_dict):
     return result
 
 
-# To save dataset as draft dataset. 
 @p.toolkit.chained_action   
 def resource_create(up_func,context, data_dict):
+    result = up_func(context, data_dict)
+    # update dataset publishing status 
     if data_dict.get('pkg_publishing_status', False):
         logic.get_action('package_patch')(context, {
             'id': data_dict.get('package_id', ''), 
             'publishing_status': data_dict.get('pkg_publishing_status')
             })
         data_dict.pop('pkg_publishing_status', None)
+    return result
+
+@p.toolkit.chained_action   
+def resource_update(up_func,context, data_dict):
     result = up_func(context, data_dict)
+    # update dataset publishing status 
+    if data_dict.get('pkg_publishing_status', False):
+        logic.get_action('package_patch')(context, {
+            'id': data_dict.get('package_id', ''), 
+            'publishing_status': data_dict.get('pkg_publishing_status')
+            })
+        data_dict.pop('pkg_publishing_status', None)
     return result
 
 
@@ -564,6 +576,7 @@ def get_actions():
         'package_create': package_create,
         'package_update': package_update,
         'resource_create': resource_create,
+        'resource_update': resource_update,
         'organization_show': organization_show,
         'organization_create': organization_create,
         'organization_update': organization_update,

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -39,7 +39,6 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     def before_search(self, search_params):
         include_drafts = search_params.get('include_drafts', False)
-        print(include_drafts)
         if not include_drafts:
             search_params.update({
                 'fq': '!(publishing_status:draft)' + search_params.get('fq', ''),

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -4,7 +4,7 @@ import json
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
 from ckanext.fcscopendata.views import vocab_tag_autocomplete
-from ckanext.fcscopendata.helpers import get_package_download_stats
+from ckanext.fcscopendata.helpers import get_package_download_stats, is_dataset_draft
 
 from ckan.lib.plugins import DefaultTranslation
 
@@ -37,6 +37,15 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             pkg_dict['tags'] = tag_list
         return pkg_dict
 
+    def before_search(self, search_params):
+        include_drafts = search_params.get('include_drafts', False)
+        print(include_drafts)
+        if not include_drafts:
+            search_params.update({
+                'fq': '!(publishing_status:draft)' + search_params.get('fq', ''),
+            })  
+        return search_params
+
     # IConfigurer
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
@@ -66,5 +75,6 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     #ITemplateHelpers
     def get_helpers(self):
         return {
-            'get_package_download_stats': get_package_download_stats
+            'get_package_download_stats': get_package_download_stats,
+            'is_dataset_draft': is_dataset_draft
         }

--- a/ckanext/fcscopendata/templates/organization/bulk_process.html
+++ b/ckanext/fcscopendata/templates/organization/bulk_process.html
@@ -78,6 +78,8 @@
                         {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type ~ '.read', id=package.name)) }}
                         {% if package.get('state', '').startswith('draft') %}
                           <span class="label label-info">{{ _('Draft') }}</span>
+                        {% elif package.get('publishing_status', '').startswith('draft') %}
+                          <span class="label label-info">{{ _('Draft') }}</span>
                         {% elif package.get('state', '').startswith('deleted') %}
                           <span class="label label-danger">{{ _('Deleted') }}</span>
                         {% endif %}

--- a/ckanext/fcscopendata/templates/package/read.html
+++ b/ckanext/fcscopendata/templates/package/read.html
@@ -3,12 +3,21 @@
 {% block primary_content_inner %}
   {{ super() }}
   {% block package_description %}
-    {% if pkg.private %}
-      <span class="dataset-private label label-inverse pull-right">
-        <i class="fa fa-lock"></i>
-        {{ _('Private') }}
-      </span>
-    {% endif %}
+    <div class="dataset-status-label">
+      {% if pkg.private %}
+          <span class="dataset-private label label-inverse">
+            <i class="fa fa-lock"></i>
+            {{ _('Private') }}
+          </span>
+      {% endif %}
+      {% if pkg.get('state', '').startswith('draft') %}
+        <span class="label label-info">{{ _('Draft') }}</span>
+      {% elif pkg.get('publishing_status', '').startswith('draft') %}
+        <span class="label label-info">{{ _('Draft') }}</span>
+      {% elif pkg.get('state', '').startswith('deleted') %}
+        <span class="label label-danger">{{ _('Deleted') }}</span>
+      {% endif %}
+    </div>
     {% block package_archive_notice %}
       {% if is_activity_archive %}
         <div class="alert alert-danger">

--- a/ckanext/fcscopendata/templates/package/snippets/package_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/package_form.html
@@ -40,7 +40,11 @@ then itself be extended to add/remove blocks of functionality. #}
         {% endif %}
       {% endblock %}
       {% block save_button %}
-        <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+      {% if form_style == 'edit' %}
+        <a class="btn btn-warning" data-module="form-save" data-module-type="draft">Save as Draft</a>
+      {% endif %}
+        <a class="btn btn-primary"  data-module="form-save" data-module-type="published">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</a>
+        <button class="btn btn-primary hidden" type="submit" name="save"></button>
       {% endblock %}
       {{ form.required_message() }}
     </div>

--- a/ckanext/fcscopendata/templates/package/snippets/package_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/package_form.html
@@ -40,11 +40,14 @@ then itself be extended to add/remove blocks of functionality. #}
         {% endif %}
       {% endblock %}
       {% block save_button %}
-      {% if form_style == 'edit' %}
-        <a class="btn btn-warning" data-module="form-save" data-module-type="draft">Save as Draft</a>
-      {% endif %}
-        <a class="btn btn-primary"  data-module="form-save" data-module-type="published">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</a>
+      {% if form_style == 'new' %}
+        <a class="btn btn-primary"  data-module="form-save" data-module-type="draft">{{ _('Next: Add Data')}}</a>
         <button class="btn btn-primary hidden" type="submit" name="save"></button>
+      {% else %}
+        <a class="btn btn-warning" data-module="form-save" data-module-type="draft">{{ _('Save as Draft')}}</a>
+        <a class="btn btn-primary" data-module="form-save" data-module-type="published">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</a>
+        <button class="btn btn-primary hidden" type="submit" name="save"></button>
+      {% endif %}
       {% endblock %}
       {{ form.required_message() }}
     </div>

--- a/ckanext/fcscopendata/templates/package/snippets/resource_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/resource_form.html
@@ -59,7 +59,13 @@
     {% endif %}
   {% endblock %}
 
-  <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
+  {% if stage %}
+    {% if stage == 1 %}
+      <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
+    {% endif %}
+  {%else %}
+    <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
+  {% endif %}
 
   <div class="form-actions">
     {% block delete_button %}

--- a/ckanext/fcscopendata/templates/package/snippets/resource_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/resource_form.html
@@ -59,9 +59,7 @@
     {% endif %}
   {% endblock %}
 
-  {% if h.is_dataset_draft(pkg_name) %}
-    <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
-  {% endif %}
+  <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
 
   <div class="form-actions">
     {% block delete_button %}

--- a/ckanext/fcscopendata/templates/package/snippets/resource_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/resource_form.html
@@ -4,7 +4,6 @@
 {% set errors = errors or {} %}
 {% set action = form_action or h.url_for(dataset_type ~ '_resource.new', id=pkg_name) %}
 
-
 <form id="resource-edit" class="dataset-form dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
 
   {% block stages %}
@@ -60,6 +59,10 @@
     {% endif %}
   {% endblock %}
 
+  {% if h.is_dataset_draft(pkg_name) %}
+    <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
+  {% endif %}
+
   <div class="form-actions">
     {% block delete_button %}
       {% if data.id %}
@@ -75,15 +78,21 @@
     {% endif %}
     {% block again_button %}
       <button class="btn btn-default" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
-    {% endblock %}
+    {% endblock %}  
     {% if stage %}
-      {% block save_button %}
-        <button class="btn btn-primary" name="save" value="go-metadata" type="submit">{% block save_button_text %}{{ _('Finish') }}{% endblock %}</button>
+         {% block save_button %}
+      {% if stage != 1 %}
+        {% if 'complete' in stage %}
+          <button class="btn btn-warning" name="save" type="submit"  data-module="form-save" data-module="form-save" data-module-type="resource-draft">{{ _('Finish & save as draft') }}</button>
+        {% endif %}
+      {% endif %}
+        <button class="btn btn-primary" name="save" value="go-metadata" type="submit">{% block save_button_text %}{{_('Finish')}}{% endblock %}</button>
       {% endblock %}
     {% else %}
       {% block add_button %}
         <button class="btn btn-primary" name="save" value="go-dataset-complete" type="submit">{{ _('Add') }}</button>
       {% endblock %}
     {% endif %}
+
   </div>
 </form>

--- a/ckanext/fcscopendata/templates/page.html
+++ b/ckanext/fcscopendata/templates/page.html
@@ -130,6 +130,7 @@
 {%- block scripts %}
   {% asset 'base/main' %}
   {% asset 'base/ckan' %}
+  {% asset 'fcscopendata/fcsc_js' %}
   {% if g.tracking_enabled %}
     {% asset 'base/tracking' %}
   {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_item.html
+++ b/ckanext/fcscopendata/templates/snippets/package_item.html
@@ -38,6 +38,8 @@ Example:
             {% block heading_meta %}
               {% if package.get('state', '').startswith('draft') %}
                 <span class="label label-info">{{ _('Draft') }}</span>
+              {% elif package.get('publishing_status', '').startswith('draft') %}
+                <span class="label label-info">{{ _('Draft') }}</span>
               {% elif package.get('state', '').startswith('deleted') %}
                 <span class="label label-danger">{{ _('Deleted') }}</span>
               {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_item.html
+++ b/ckanext/fcscopendata/templates/snippets/package_item.html
@@ -40,6 +40,8 @@ Example:
                 <span class="label label-info">{{ _('Draft') }}</span>
               {% elif package.get('publishing_status', '').startswith('draft') %}
                 <span class="label label-info">{{ _('Draft') }}</span>
+               {% elif package.get('approval_state', '').startswith('pending') %}
+                <span class="label label-warning">{{ _('pending') }}</span>
               {% elif package.get('state', '').startswith('deleted') %}
                 <span class="label label-danger">{{ _('Deleted') }}</span>
               {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_item.html
+++ b/ckanext/fcscopendata/templates/snippets/package_item.html
@@ -43,7 +43,9 @@ Example:
               {% elif package.get('approval_state', '').startswith('pending') and in_review%}
                 <span class="label label-warning">{{ _('Review requested')  }}</span>
               {% elif package.get('approval_state', '').startswith('pending')%}
-              <span class="label label-warning">{{ _('pending')  }}</span>
+              <span class="label label-warning">{{ _('Pending')  }}</span>
+              {% elif package.get('approval_state', '').startswith('rejected')%}
+              <span class="label label-danger">{{ _('Rejected')  }}</span>
               {% elif package.get('state', '').startswith('deleted') %}
                 <span class="label label-danger">{{ _('Deleted') }}</span>
               {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_item.html
+++ b/ckanext/fcscopendata/templates/snippets/package_item.html
@@ -40,8 +40,10 @@ Example:
                 <span class="label label-info">{{ _('Draft') }}</span>
               {% elif package.get('publishing_status', '').startswith('draft') %}
                 <span class="label label-info">{{ _('Draft') }}</span>
-               {% elif package.get('approval_state', '').startswith('pending') %}
-                <span class="label label-warning">{{ _('pending') }}</span>
+              {% elif package.get('approval_state', '').startswith('pending') and in_review%}
+                <span class="label label-warning">{{ _('Review requested')  }}</span>
+              {% elif package.get('approval_state', '').startswith('pending')%}
+              <span class="label label-warning">{{ _('pending')  }}</span>
               {% elif package.get('state', '').startswith('deleted') %}
                 <span class="label label-danger">{{ _('Deleted') }}</span>
               {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_list.html
+++ b/ckanext/fcscopendata/templates/snippets/package_list.html
@@ -19,7 +19,8 @@ Example:
     <ul class="{{ list_class or 'dataset-list list-unstyled' }}">
     	{% block package_list_inner %}
 	      {% for package in packages %}
-	        {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title %}
+	        {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, 
+             banner=banner, truncate=truncate, truncate_title=truncate_title, in_review=in_review %}
 	      {% endfor %}
 	    {% endblock %}
     </ul>


### PR DESCRIPTION
**Fix for** https://github.com/FCSCOpendata/ckanext-fcscopendata/issues/62
This PR includes the following changes. 
1.  Added hidden metafield  `publishing_status` on dataset create/update UI. 
     -  https://github.com/FCSCOpendata/ckanext-scheming/pull/11
2.  Added `form-save` modules which will update the `publishing_status` filed value based on the button clicked by the user while creating/updating the dataset (Save as draft and publish ).
3.  Added `before_search` function to hide the `draft` dataset for public users on search.
4.  Updated `check_access` on the `package_show` action so that only users who have edit access can view the draft dataset. (Restricting  anonymous  access)
5.  Updated templates as needed. 

### Screenshots: 
**Dataset create UI Page:** 
![image](https://user-images.githubusercontent.com/87696933/171336156-17b3a4eb-5fa4-45f5-9a68-f8edf3361aac.png)

**Dataset edit  UI page:**
![image](https://user-images.githubusercontent.com/87696933/171336254-b034586b-cc5b-44d2-9e5c-d339a04396f2.png)

**Resource add/edit  UI page for draft dataset **

![image](https://user-images.githubusercontent.com/87696933/171336408-c00a20aa-33b2-4689-81b1-533052fe3477.png)







