### PR TITLE
Enable group list for editors

### DIFF
--- a/ckanext/fcscopendata/assets/home.css
+++ b/ckanext/fcscopendata/assets/home.css
@@ -581,6 +581,20 @@ button.active {
 .stages li.active:before {
   color: #252525;
 }
+
+/* label */
+.dataset-status-label {
+  display: flex;
+  justify-content: flex-end;
+  flex-direction: row;
+}
+
+.dataset-status-label span {
+  margin-left: 2px;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
 /* About */
 .about .page-heading {
   color: #003164;
@@ -695,6 +709,12 @@ button.active {
   background-color: #c9a926;
   border-color: #c9a926;
 }
+
+button.btn.btn-warning:hover{
+  background-color: #ec971f !important;
+  border-color: #d58512;
+}
+
 .wrapper {
   border: 1px solid #e0e0e0;
   border-radius: 0;

--- a/ckanext/fcscopendata/assets/javascript/form-submit.js
+++ b/ckanext/fcscopendata/assets/javascript/form-submit.js
@@ -1,0 +1,40 @@
+this.ckan.module('form-save', function (jQuery) {
+  return {
+    /* An object of module options */
+    options: {
+      type:''
+    },
+    /* Sets up the event listeners for the object. Called internally by
+     * module.createInstance().
+     *
+     * Returns nothing.
+     */
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/);
+      this.el.on('click', this._onClick);
+    },
+
+    /* Event handler that displays the confirm dialog */
+    _onClick: function (event) {
+    
+      if(this.options.type === 'draft'){
+        event.preventDefault();
+        var form = $('#dataset-edit')
+        $('#field-publishing_status').val('draft')
+        form.find('button[name=save]').click()
+      }
+      if(this.options.type === 'published'){
+        event.preventDefault();
+        var form = $('#dataset-edit')
+        $('#field-publishing_status').val('published')
+        form.find('button[name=save]').click()
+      }
+      if(this.options.type === 'resource-draft'){
+        event.preventDefault();
+        var form = $('#resource-edit')
+        $('#field-pkg_publishing_status').val('draft')
+        form.find('button[value=go-metadata]').click()
+      }
+    },
+  };
+});

--- a/ckanext/fcscopendata/assets/webassets.yml
+++ b/ckanext/fcscopendata/assets/webassets.yml
@@ -13,6 +13,15 @@
 #   contents:
 #     - css/fcscopendata.css
 
+fcsc_js:
+  filter: rjsmin
+  output: ckanext-fcscopendata/%(version)s-form-submit.js
+  contents:
+    - javascript/form-submit.js
+  extra:
+    preload:
+      - base/main
+
 home_css:
   filter: cssrewrite
   output: ckanext-fcscopendata/%(version)s-home.css

--- a/ckanext/fcscopendata/helpers.py
+++ b/ckanext/fcscopendata/helpers.py
@@ -1,5 +1,7 @@
 import ckan.logic as logic
 import ckan.model as model
+import ckan.model as model
+import ckan.lib.dictization.model_dictize as model_dictize
 import logging
 
 log = logging.getLogger(__name__)
@@ -7,3 +9,16 @@ def get_package_download_stats(package_id):
     context = {'model': model, 'session': model.Session}
     stats = logic.get_action('package_show')(context, {'id': package_id})
     return stats['total_downloads']
+
+def get_dataset_group_list():
+    context = {'model':model}
+    q = model.Session.query(model.Group) \
+        .filter(model.Group.is_organization == False) \
+        .filter(model.Group.state == 'active')
+    groups = q.all()
+    group_list = model_dictize.group_list_dictize(groups, context)
+
+    group_dropdown = [[group[u'id'], group[u'display_name']]
+                          for group in group_list]
+
+    return group_dropdown

--- a/ckanext/fcscopendata/helpers.py
+++ b/ckanext/fcscopendata/helpers.py
@@ -22,3 +22,11 @@ def get_dataset_group_list():
                           for group in group_list]
 
     return group_dropdown
+  
+def is_dataset_draft(package_id):
+    context = {'model': model, 'session': model.Session}
+    dataset = logic.get_action('package_show')(context, {'id': package_id})
+    if dataset.get('publishing_status', '') == 'draft':
+        return True
+    else:
+        return False

--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from unittest import result
 import ckan.plugins.toolkit as tk
 import ckan.plugins as p
 import ckan.logic as logic
@@ -8,12 +7,12 @@ import ckan.lib.helpers as h
 import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.uploader as uploader
 from ckan.plugins.toolkit import ValidationError
-from datetime import date, datetime
+from datetime import datetime
 import ckan.lib.helpers as h
 import ckan.lib.uploader as uploader
 import ckan.model as model
 from ckan.common import c
-from ckan.authz import users_role_for_group_or_org, is_sysadmin
+from ckan.authz import users_role_for_group_or_org
 
 
 ValidationError = logic.ValidationError
@@ -562,20 +561,7 @@ def package_show(up_func,context,data_dict):
         result['total_downloads'] = 0
     return result
 
-@p.toolkit.chained_action
-def member_create(up_func, context, data_dict):
-    sysadmin = is_sysadmin(context['user'])
-    if not sysadmin:
-        is_memeber_of_group = users_role_for_group_or_org(data_dict['id'], context['user'])
-        if not is_memeber_of_group:
-            member_dict = {
-                'id': data_dict['id'],
-                'object': c.userobj.id,
-                'object_type': 'user',
-                'capacity': 'member',
-                }
-    result = up_func(dict(context, ignore_auth=True), data_dict)
-    return result
+
 
 def get_actions():
     return {
@@ -594,7 +580,6 @@ def get_actions():
         'vocabulary_show': vocabulary_show,
         'package_show': package_show,
         'package_search': package_search,
-        'member_create': member_create
     }
 
 

--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -537,6 +537,9 @@ def vocabulary_update(up_func,context,data_dict):
 @logic.side_effect_free
 def package_show(up_func,context,data_dict): 
     result = up_func(context, data_dict)
+    if result.get('publishing_status', '') == 'draft':
+        tk.check_access('package_update', context, {'id': data_dict.get('id')})
+
     id = result.get('id')
     try:
         result['total_downloads'] = logic.get_action('package_stats')(context, {'package_id': id})
@@ -562,11 +565,38 @@ def package_show(up_func,context,data_dict):
     return result
 
 
+@p.toolkit.chained_action   
+def resource_create(up_func,context, data_dict):
+    result = up_func(context, data_dict)
+    # update dataset publishing status 
+    if data_dict.get('pkg_publishing_status', False):
+        logic.get_action('package_patch')(context, {
+            'id': data_dict.get('package_id', ''), 
+            'publishing_status': data_dict.get('pkg_publishing_status')
+            })
+        data_dict.pop('pkg_publishing_status', None)
+    return result
+
+@p.toolkit.chained_action   
+
+def resource_update(up_func,context, data_dict):
+    result = up_func(context, data_dict)
+    # update dataset publishing status 
+    if data_dict.get('pkg_publishing_status', False):
+        logic.get_action('package_patch')(context, {
+            'id': data_dict.get('package_id', ''), 
+            'publishing_status': data_dict.get('pkg_publishing_status')
+            })
+        data_dict.pop('pkg_publishing_status', None)
+    return result
+
 
 def get_actions():
     return {
         'package_create': package_create,
         'package_update': package_update,
+        'resource_create': resource_create,
+        'resource_update': resource_update,
         'organization_show': organization_show,
         'organization_create': organization_create,
         'organization_update': organization_update,
@@ -579,7 +609,7 @@ def get_actions():
         'vocabulary_update': vocabulary_update,
         'vocabulary_show': vocabulary_show,
         'package_show': package_show,
-        'package_search': package_search,
+        'package_search': package_search
     }
 
 

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -1,9 +1,10 @@
+from email.policy import default
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import json
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
-from ckanext.fcscopendata.views import vocab_tag_autocomplete
+from ckanext.fcscopendata.views import vocab_tag_autocomplete, GroupManage
 from ckanext.fcscopendata.helpers import get_package_download_stats, get_dataset_group_list
 
 from ckan.lib.plugins import DefaultTranslation
@@ -53,6 +54,8 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         # Add plugin url rules to Blueprint object
         blueprint.add_url_rule(u'/api/2/util/vocab/tag/autocomplete', methods=[u'GET'], 
                                 view_func=vocab_tag_autocomplete)
+        blueprint.add_url_rule(u'/dataset/groups/<id>', defaults= {u'package_type': u'dataset'},
+                                view_func=GroupManage.as_view(str(u'groups')))
         return blueprint
 
     def get_actions(self):

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -4,7 +4,7 @@ import json
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
 from ckanext.fcscopendata.views import vocab_tag_autocomplete
-from ckanext.fcscopendata.helpers import get_package_download_stats
+from ckanext.fcscopendata.helpers import get_package_download_stats, get_dataset_group_list
 
 from ckan.lib.plugins import DefaultTranslation
 
@@ -66,5 +66,6 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
     #ITemplateHelpers
     def get_helpers(self):
         return {
-            'get_package_download_stats': get_package_download_stats
+            'get_package_download_stats': get_package_download_stats,
+            'get_dataset_group_list': get_dataset_group_list
         }

--- a/ckanext/fcscopendata/plugin.py
+++ b/ckanext/fcscopendata/plugin.py
@@ -5,7 +5,7 @@ import json
 from ckanext.fcscopendata.logic import action
 import ckanext.fcscopendata.cli as cli
 from ckanext.fcscopendata.views import vocab_tag_autocomplete, GroupManage
-from ckanext.fcscopendata.helpers import get_package_download_stats, get_dataset_group_list
+from ckanext.fcscopendata.helpers import get_package_download_stats, get_dataset_group_list, is_dataset_draft
 
 from ckan.lib.plugins import DefaultTranslation
 
@@ -37,6 +37,14 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
                 tag_list.append(tag['name'])
             pkg_dict['tags'] = tag_list
         return pkg_dict
+
+    def before_search(self, search_params):
+        include_drafts = search_params.get('include_drafts', False)
+        if not include_drafts:
+            search_params.update({
+                'fq': '!(publishing_status:draft)' + search_params.get('fq', ''),
+            })  
+        return search_params
 
     # IConfigurer
     def update_config(self, config_):
@@ -71,4 +79,5 @@ class FcscopendataPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'get_package_download_stats': get_package_download_stats,
             'get_dataset_group_list': get_dataset_group_list
+            'is_dataset_draft': is_dataset_draft
         }

--- a/ckanext/fcscopendata/templates/organization/bulk_process.html
+++ b/ckanext/fcscopendata/templates/organization/bulk_process.html
@@ -78,6 +78,8 @@
                         {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type ~ '.read', id=package.name)) }}
                         {% if package.get('state', '').startswith('draft') %}
                           <span class="label label-info">{{ _('Draft') }}</span>
+                        {% elif package.get('publishing_status', '').startswith('draft') %}
+                          <span class="label label-info">{{ _('Draft') }}</span>
                         {% elif package.get('state', '').startswith('deleted') %}
                           <span class="label label-danger">{{ _('Deleted') }}</span>
                         {% endif %}

--- a/ckanext/fcscopendata/templates/package/group_list.html
+++ b/ckanext/fcscopendata/templates/package/group_list.html
@@ -7,6 +7,7 @@
   {% if group_dropdown %}
     <form class="add-to-group" method="post">
       <select id="field-add_group" name="group_added" data-module="autocomplete">
+        {% set group_dropdown = h.get_dataset_group_list() %}
         {% for option in group_dropdown %}
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
         {% endfor %}

--- a/ckanext/fcscopendata/templates/package/read.html
+++ b/ckanext/fcscopendata/templates/package/read.html
@@ -3,12 +3,21 @@
 {% block primary_content_inner %}
   {{ super() }}
   {% block package_description %}
-    {% if pkg.private %}
-      <span class="dataset-private label label-inverse pull-right">
-        <i class="fa fa-lock"></i>
-        {{ _('Private') }}
-      </span>
-    {% endif %}
+    <div class="dataset-status-label">
+      {% if pkg.private %}
+          <span class="dataset-private label label-inverse">
+            <i class="fa fa-lock"></i>
+            {{ _('Private') }}
+          </span>
+      {% endif %}
+      {% if pkg.get('state', '').startswith('draft') %}
+        <span class="label label-info">{{ _('Draft') }}</span>
+      {% elif pkg.get('publishing_status', '').startswith('draft') %}
+        <span class="label label-info">{{ _('Draft') }}</span>
+      {% elif pkg.get('state', '').startswith('deleted') %}
+        <span class="label label-danger">{{ _('Deleted') }}</span>
+      {% endif %}
+    </div>
     {% block package_archive_notice %}
       {% if is_activity_archive %}
         <div class="alert alert-danger">

--- a/ckanext/fcscopendata/templates/package/snippets/package_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/package_form.html
@@ -40,7 +40,14 @@ then itself be extended to add/remove blocks of functionality. #}
         {% endif %}
       {% endblock %}
       {% block save_button %}
-        <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+      {% if form_style == 'new' %}
+        <a class="btn btn-primary"  data-module="form-save" data-module-type="draft">{{ _('Next: Add Data')}}</a>
+        <button class="btn btn-primary hidden" type="submit" name="save"></button>
+      {% else %}
+        <a class="btn btn-warning" data-module="form-save" data-module-type="draft">{{ _('Save as Draft')}}</a>
+        <a class="btn btn-primary" data-module="form-save" data-module-type="published">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</a>
+        <button class="btn btn-primary hidden" type="submit" name="save"></button>
+      {% endif %}
       {% endblock %}
       {{ form.required_message() }}
     </div>

--- a/ckanext/fcscopendata/templates/package/snippets/resource_form.html
+++ b/ckanext/fcscopendata/templates/package/snippets/resource_form.html
@@ -4,7 +4,6 @@
 {% set errors = errors or {} %}
 {% set action = form_action or h.url_for(dataset_type ~ '_resource.new', id=pkg_name) %}
 
-
 <form id="resource-edit" class="dataset-form dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
 
   {% block stages %}
@@ -60,6 +59,14 @@
     {% endif %}
   {% endblock %}
 
+  {% if stage %}
+    {% if stage == 1 %}
+      <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
+    {% endif %}
+  {%else %}
+    <div class="alert alert-warning" role="alert">You're updating this resource as a draft. Once you done with updating, you can submit the dataset for review by visiting the dataset edit page and clicking the "Finish Update" button <a href="{{ h.url_for('dataset.edit', id=pkg_name)}}"> dataset edit page.</a> </div>
+  {% endif %}
+
   <div class="form-actions">
     {% block delete_button %}
       {% if data.id %}
@@ -75,15 +82,21 @@
     {% endif %}
     {% block again_button %}
       <button class="btn btn-default" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
-    {% endblock %}
+    {% endblock %}  
     {% if stage %}
-      {% block save_button %}
-        <button class="btn btn-primary" name="save" value="go-metadata" type="submit">{% block save_button_text %}{{ _('Finish') }}{% endblock %}</button>
+         {% block save_button %}
+      {% if stage != 1 %}
+        {% if 'complete' in stage %}
+          <button class="btn btn-warning" name="save" type="submit"  data-module="form-save" data-module="form-save" data-module-type="resource-draft">{{ _('Finish & save as draft') }}</button>
+        {% endif %}
+      {% endif %}
+        <button class="btn btn-primary" name="save" value="go-metadata" type="submit">{% block save_button_text %}{{_('Finish')}}{% endblock %}</button>
       {% endblock %}
     {% else %}
       {% block add_button %}
         <button class="btn btn-primary" name="save" value="go-dataset-complete" type="submit">{{ _('Add') }}</button>
       {% endblock %}
     {% endif %}
+
   </div>
 </form>

--- a/ckanext/fcscopendata/templates/page.html
+++ b/ckanext/fcscopendata/templates/page.html
@@ -130,6 +130,7 @@
 {%- block scripts %}
   {% asset 'base/main' %}
   {% asset 'base/ckan' %}
+  {% asset 'fcscopendata/fcsc_js' %}
   {% if g.tracking_enabled %}
     {% asset 'base/tracking' %}
   {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_item.html
+++ b/ckanext/fcscopendata/templates/snippets/package_item.html
@@ -38,6 +38,12 @@ Example:
             {% block heading_meta %}
               {% if package.get('state', '').startswith('draft') %}
                 <span class="label label-info">{{ _('Draft') }}</span>
+              {% elif package.get('publishing_status', '').startswith('draft') %}
+                <span class="label label-info">{{ _('Draft') }}</span>
+              {% elif package.get('approval_state', '').startswith('pending') and in_review%}
+                <span class="label label-warning">{{ _('Review requested')  }}</span>
+              {% elif package.get('approval_state', '').startswith('pending')%}
+              <span class="label label-warning">{{ _('pending')  }}</span>
               {% elif package.get('state', '').startswith('deleted') %}
                 <span class="label label-danger">{{ _('Deleted') }}</span>
               {% endif %}

--- a/ckanext/fcscopendata/templates/snippets/package_list.html
+++ b/ckanext/fcscopendata/templates/snippets/package_list.html
@@ -19,7 +19,8 @@ Example:
     <ul class="{{ list_class or 'dataset-list list-unstyled' }}">
     	{% block package_list_inner %}
 	      {% for package in packages %}
-	        {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title %}
+	        {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, 
+             banner=banner, truncate=truncate, truncate_title=truncate_title, in_review=in_review %}
 	      {% endfor %}
 	    {% endblock %}
     </ul>

--- a/ckanext/fcscopendata/views.py
+++ b/ckanext/fcscopendata/views.py
@@ -1,8 +1,8 @@
 import ckan.model as model
 from ckan.common import _, g, request
-from ckan.logic import get_action
+import ckan.plugins.toolkit as tk
 from ckan.views.api import _finish_ok
-
+from ckan.views.dataset import GroupView
 
 def vocab_tag_autocomplete():
     q = request.args.get(u'incomplete', u'')
@@ -10,14 +10,14 @@ def vocab_tag_autocomplete():
                    u'user': g.user, u'auth_user_obj': g.userobj}
 
     limit = request.args.get(u'limit', 10)
-    vocab_list = get_action(u'vocabulary_list')(context, {})
+    vocab_list = tk.get_action(u'vocabulary_list')(context, {})
 
     tag_list = []
     if q:
         data_dict = {u'q': q, u'limit': limit}
 
         for vocab in vocab_list:
-            tags = get_action(u'tag_autocomplete')(context, 
+            tags = tk.get_action(u'tag_autocomplete')(context, 
                 {**data_dict,'vocabulary_id': vocab['id'] })
             for tag_item in tags:
                 tag_list.append(tag_item) 
@@ -29,3 +29,44 @@ def vocab_tag_autocomplete():
     }
 
     return _finish_ok(resultSet)
+
+class GroupManage(GroupView):
+    def post(self, package_type, id):
+        context, pkg_dict = self._prepare(id)
+        new_group = request.form.get(u'group_added')
+
+        try:
+            tk.check_access('package_update', context, pkg_dict)
+        except tk.NotFound:
+            tk.abort(404, _('Dataset not found'))
+        except tk.NotAuthorized:
+            tk.abort(403, _('User %r not authorized to manage themes'))
+
+        if new_group:
+            data_dict = {
+                u"id": new_group,
+                u"object": id,
+                u"object_type": u'package',
+                u"capacity": u'public'
+            }
+            try:
+                tk.get_action(u'member_create')(dict(context, ignore_auth=True), data_dict)
+            except tk.NotFound:
+                return tk.abort(404, _(u'Group not found'))
+
+        removed_group = None
+        for param in request.form:
+            if param.startswith(u'group_remove'):
+                removed_group = param.split(u'.')[-1]
+                break
+        if removed_group:
+            data_dict = {
+                u"id": removed_group,
+                u"object": id,
+                u"object_type": u'package'
+            }
+            try:
+                tk.get_action(u'member_delete')(dict(context, ignore_auth=True), data_dict)
+            except tk.NotFound:
+                return tk.abort(404, _(u'Group not found'))
+        return tk.h.redirect_to(u'{}.groups'.format(package_type), id=id)


### PR DESCRIPTION
- Uses a function `get_dataset_group_list` to get the list of groups from the dropdown without authorizing for members
- Override the member_create function to allow the creation of the member by the theme editors