### PR TITLE
Editor user cannot publish dataset as public.

### DIFF
--- a/ckanext/fcscopendata/assets/javascript/dataset-visibility.js
+++ b/ckanext/fcscopendata/assets/javascript/dataset-visibility.js
@@ -1,0 +1,60 @@
+/* Dataset visibility toggler
+ * When no organization is selected in the org dropdown then set visibility to
+ * public always and disable dropdown
+ */
+delete this.ckan.module.registry['dataset-visibility']
+this.ckan.module('dataset-visibility', function ($) {
+    return {
+      currentValue: false,
+      options: {
+        organizations: $('#field-organizations'),
+        visibility: $('#field-private'),
+        currentValue: null,
+        authorizedOrg: []
+      },
+  
+      initialize: function() {
+        $.proxyAll(this, /_on/);
+        this.options.currentValue = this.options.visibility.val();
+        this.options.organizations.on('change', this._onOrganizationChange);
+        this._onOrganizationChange();
+        var self = this;
+        this.sandbox.client.call(
+          'GET', 'organization_list_for_user', '', function(data) {
+            self.options.authorizedOrg = data.result
+              var capacity = data.result.find(
+                (org) => org.id === self.options.organizations.val()).capacity
+              var value = self.options.organizations.val();
+              if (value && capacity === 'admin' ) {
+                self.options.visibility
+                  .prop('disabled', false)
+                  .val(self.options.currentValue);
+              } else {
+                self.options.visibility
+                  .prop('disabled', true)
+                  .val('True');
+              }
+          },
+        )
+      },
+  
+      _onOrganizationChange: function() {
+        var capacity = false
+        if (this.options.authorizedOrg.length != 0) {
+          capacity = this.options.authorizedOrg.find(
+            (org) => org.id === this.options.organizations.val()).capacity
+        }       
+        var value = this.options.organizations.val();
+        if (value && capacity === 'admin') {
+          this.options.visibility
+            .prop('disabled', false)
+            .val(this.options.currentValue);
+        } else {
+          this.options.visibility
+            .prop('disabled', true)
+            .val('True');
+        }
+      }
+    };
+  });
+  

--- a/ckanext/fcscopendata/assets/webassets.yml
+++ b/ckanext/fcscopendata/assets/webassets.yml
@@ -18,6 +18,7 @@ fcsc_js:
   output: ckanext-fcscopendata/%(version)s-form-submit.js
   contents:
     - javascript/form-submit.js
+    - javascript/dataset-visibility.js
   extra:
     preload:
       - base/main

--- a/ckanext/fcscopendata/logic/action.py
+++ b/ckanext/fcscopendata/logic/action.py
@@ -36,6 +36,10 @@ def theme_update(pkg, groups, context):
             delete_groups.append(member.id)
     return delete_groups
 
+def if_editor_publishing_dataset(owner_org, context):
+    user_capacity = users_role_for_group_or_org(owner_org, context['user'])
+    return user_capacity != 'admin'
+
 def _add_user_as_memeber_on_groups(groups, context):
     for group_id in groups:
         is_memeber_of_group = users_role_for_group_or_org(group_id, context['user'])
@@ -128,6 +132,10 @@ def package_create(up_func, context, data_dict):
     # Do not create free tags. 
     data_dict['tag_string'] = ''
 
+    # Always publish dataset as private for editor user
+    if if_editor_publishing_dataset(data_dict.get('owner_org', ''), context):
+        data_dict['private'] = True
+
     # Add selected groups in package
     if data_dict.get('themes'):
         pkg_group = data_dict.get('themes')
@@ -173,6 +181,10 @@ def package_update(up_func, context, data_dict):
 
         # Do not create free tags. 
         data_dict['tag_string'] = ''
+
+    # Always publish dataset as private for editor user
+    if if_editor_publishing_dataset(data_dict.get('owner_org', ''), context):
+        data_dict['private'] = True
 
     # Add selected groups in package
     if data_dict.get('themes'):


### PR DESCRIPTION
- visibility js modules `dataset-visibility` updated to disallow visibility UI selection for editor users. 
-  `package_create` and `package_update` action updated for always publish as private dataset when editor user updates the dataset. 