### PR TITLE
Admin can view and sort  review pending/rejected dataset in search page

### DIFF
--- a/ckanext/fcscopendata/lib/util.py
+++ b/ckanext/fcscopendata/lib/util.py
@@ -24,6 +24,8 @@ def theme_update(pkg, groups, context):
 
 def editor_publishing_dataset(owner_org, context):
     user_capacity = users_role_for_group_or_org(owner_org, context['user'])
+    if context['auth_user_obj'].sysadmin:
+        return False
     return user_capacity != 'admin'
 
 def add_user_as_memeber_on_groups(groups, context):

--- a/ckanext/fcscopendata/templates/package/search.html
+++ b/ckanext/fcscopendata/templates/package/search.html
@@ -31,7 +31,9 @@
           (_('Name Descending'), 'title_string desc'),
           (_('Last Modified'), 'metadata_modified desc'),
           (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ,
-          (_('Draft'), 'publishing_status asc') if g.userobj.sysadmin else (false, false) 
+          (_('Draft'), 'publishing_status asc') if g.userobj.sysadmin else (false, false),
+          (_('Review Requested'), 'approval_state asc') if g.userobj.sysadmin else (false, false),
+          (_('Rejected'), 'approval_state desc') if g.userobj.sysadmin else (false, false) 
           ]
         %}
         {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=query_error, fields=fields %}

--- a/ckanext/fcscopendata/templates/snippets/package_list.html
+++ b/ckanext/fcscopendata/templates/snippets/package_list.html
@@ -20,7 +20,7 @@ Example:
     	{% block package_list_inner %}
 	      {% for package in packages %}
 	        {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, 
-             banner=banner, truncate=truncate, truncate_title=truncate_title, in_review=in_review %}
+             banner=banner, truncate=truncate, truncate_title=truncate_title, in_review=true if g.userobj.sysadmin else in_review %}
 	      {% endfor %}
 	    {% endblock %}
     </ul>


### PR DESCRIPTION
- **Feature  Implemented**:  admin can view and sort review pending/rejected datasets in search page.
-  **Bug fixed**:  Even though sysadmin is not admin of org, he/she can change the dataset visibility metadata as public. 