### PR TITLE
 groups/organizations parameter on group_list/organization not working bug fix

### DIFF
--- a/ckanext/fcscopendata/logic/action/__init__.py
+++ b/ckanext/fcscopendata/logic/action/__init__.py
@@ -1,6 +1,8 @@
 from ckanext.fcscopendata.logic.action.get import (
+    group_list,
     package_search,
     package_show,
+    organization_list,
     organization_show,
     group_show,
     tag_show,

--- a/ckanext/fcscopendata/logic/action/get.py
+++ b/ckanext/fcscopendata/logic/action/get.py
@@ -86,6 +86,24 @@ def organization_show(up_func,context,data_dict):
 
 @p.toolkit.chained_action   
 @tk.side_effect_free
+def group_list(up_func,context,data_dict):
+    groups = data_dict.get('groups', False)
+    if groups:
+        data_dict['groups'] = json.loads(groups)
+    return up_func(context, data_dict)  
+
+
+@p.toolkit.chained_action   
+@tk.side_effect_free
+def organization_list(up_func,context,data_dict):
+    organizations = data_dict.get('organizations', False)
+    if organizations:
+        data_dict['organizations'] = json.loads(organizations)
+    return up_func(context, data_dict)  
+
+
+@p.toolkit.chained_action   
+@tk.side_effect_free
 def group_show(up_func,context,data_dict): 
     result = up_func(context, data_dict)  
 


### PR DESCRIPTION
Fix for: https://github.com/FCSCOpendata/fcsc-deploy/issues/41

Toolchain action added for `group_list` and `organization_list` to convert string type list to python list. 

**Example of groups string list params:** 
`group_list?groups=["groupB","groupA"]&all_fields=true`