### PR TITLE
Bilingual tag on facets search  and  download count on package_search API

### DIFF
--- a/ckanext/fcscopendata/logic/action/get.py
+++ b/ckanext/fcscopendata/logic/action/get.py
@@ -41,6 +41,21 @@ def package_search(up_func, context, data_dict):
                 for index, tag in enumerate(result['results'][idx]['tags']):
                     result['results'][idx]['tags'][index] =  \
                     tk.get_action('tag_show')(context, {'id': tag['id'] })
+
+    facet_tags = result.get('search_facets', {}).get('tags', {}).get('items', [])
+    new_facet_tags = []
+    if facet_tags:
+        for index, tag in enumerate(facet_tags):
+            tag_obj = model.Session.query(model.Tag).filter(model.Tag.name == tag['name']).first()
+            if tag_obj._extras:
+                extras = model_dictize.extras_dict_dictize(
+                        tag_obj._extras, context)
+                translated = list(filter(lambda d: d['key'] in ['name_translated'], extras))
+                if translated:   
+                    field_value = json.loads(translated[0].get('value', {}))
+                    new_facet_tags.append({**tag, 'name_translated': field_value  })
+        result['search_facets']['tags']['items'] = new_facet_tags
+
     return result
 
 @p.toolkit.chained_action   

--- a/ckanext/fcscopendata/logic/action/get.py
+++ b/ckanext/fcscopendata/logic/action/get.py
@@ -21,6 +21,13 @@ def package_search(up_func, context, data_dict):
                     'user': tk.c.user, 'auth_user_obj': tk.c.userobj}
                     
         for idx, pkg in enumerate(result['results']):
+            try:
+               result['results'][idx]['total_downloads'] = tk.get_action('package_stats') \
+                                                            (context, {'package_id': pkg['id']})
+            except:
+                log.error('package {id} stats not available'.format(id=pkg['id']))
+                result['results'][idx]['total_downloads'] = 0
+            
             if pkg.get('groups', []):
                 for gidx, group in enumerate(pkg.get('groups', [])):
                     group_dict = tk.get_action('group_show')(context, {'id': group.get('id')})


### PR DESCRIPTION
Fix for: #89 , #90. 
I have also improved the previous code as well. Before, It was calling multiple CKAN actions to fetch bilingual fileds for groups, organizations, and tags. Now it has been fetching from solr DB which will improve the load performance.