### PR TITLE
[create.py] Adds checks for creating start and end period

### DIFF
--- a/ckanext/fcscopendata/logic/action/create.py
+++ b/ckanext/fcscopendata/logic/action/create.py
@@ -33,7 +33,7 @@ def package_create(up_func, context, data_dict):
         except:
             try:
                 start_date = datetime.strptime(str(start_period), '%Y-%m-%d').isoformat()
-             except ValueError as ve:
+            except ValueError as ve:
                 log.error('%s for start period', ve)
                 raise tk.ValidationError(
                         error_dict =  { 'start_period' : ['Start period needs to be in the format YYYY-MM or YYYY-MM-DD'] },
@@ -46,7 +46,7 @@ def package_create(up_func, context, data_dict):
         except:
             try:
                 end_date = datetime.strptime(str(end_period), '%Y-%m-%d').isoformat()
-             except ValueError as ve:
+            except ValueError as ve:
                 log.error('%s for end period', ve)
                 raise tk.ValidationError(
                         error_dict =  { 'end_period' : ['End period needs to be in the format YYYY-MM or YYYY-MM-DD'] },

--- a/ckanext/fcscopendata/logic/action/create.py
+++ b/ckanext/fcscopendata/logic/action/create.py
@@ -28,11 +28,30 @@ def package_create(up_func, context, data_dict):
     end_period = data_dict.get('end_period', False)
 
     if start_period:
-        start_date = datetime.strptime(str(start_period), '%Y-%m').isoformat()
+        try:
+            start_date = datetime.strptime(str(start_period), '%Y-%m').isoformat()
+        except:
+            try:
+                start_date = datetime.strptime(str(start_period), '%Y-%m-%d').isoformat()
+             except ValueError as ve:
+                log.error('%s for start period', ve)
+                raise tk.ValidationError(
+                        error_dict =  { 'start_period' : ['Start period needs to be in the format YYYY-MM or YYYY-MM-DD'] },
+                        error_summary = ['Start period needs to be in the format YYYY-MM or YYYY-MM-DD']
+                    )
 
     if end_period:
-        end_date = datetime.strptime(str(end_period), '%Y-%m').isoformat()
-
+        try:
+            end_date = datetime.strptime(str(end_period), '%Y-%m').isoformat()
+        except:
+            try:
+                end_date = datetime.strptime(str(end_period), '%Y-%m-%d').isoformat()
+             except ValueError as ve:
+                log.error('%s for end period', ve)
+                raise tk.ValidationError(
+                        error_dict =  { 'end_period' : ['End period needs to be in the format YYYY-MM or YYYY-MM-DD'] },
+                        error_summary = ['End period needs to be in the format YYYY-MM or YYYY-MM-DD']
+                    )
     if start_period and end_period:
         if start_date > end_date:
             raise tk.ValidationError(


### PR DESCRIPTION
## Description

* Currently the site breaks if the format for start and end period is wrong while creating the dataset
* Initially the format was supposed to be `YYYY-MM` for start and end period but since a lot of datasets on prod have the format `YYYY-MM-DD`, we enabled the datasets to be created with that format

## Fix

- Adds checks for creating start and end period to be either `YYYY-MM` or `YYYY-MM-DD`
- Fixes the internal server error if the format is wrong for the dates by prompting the error message instead of breaking the site


![image](https://user-images.githubusercontent.com/57398621/209967863-b9bfbce4-c6ab-4a28-abf5-f31a804fef0c.png)

Also for **End Period**
![image](https://user-images.githubusercontent.com/57398621/209967965-f5c21b95-890a-465b-be7e-24a77b5c09c7.png)
