### PR TITLE
[invite_user.txt] Use proper tags for email url

### DIFF
--- a/ckanext/fcscopendata/templates/emails/invite_user.txt
+++ b/ckanext/fcscopendata/templates/emails/invite_user.txt
@@ -6,9 +6,7 @@ A user has already been created for you with the username {{ user_name }}. You c
 
 You have been added to the {{ group_type }} {{ group_title }} with the following role: {{ role_name }}.
 
-To accept this invite, please reset your password at:
-
-   {{ reset_link }}
+To accept this invite, please reset your password <a href="{{ reset_link }}">here</a>
 
 
 Have a nice day.


### PR DESCRIPTION
## Bug
Currently the link from our SMTP server is being sent as plain text in the template which is causing it not to be rendered properly.
## Fix
Use <a> tag and using the href attribute to specify the link destination to ensure that the link is correctly rendered in the template.